### PR TITLE
feat: Modify Dockerfile and auth for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /app/frontend
 # Copy frontend package files and install dependencies
 COPY frontend/package.json ./
 COPY frontend/package-lock.json ./
-# If you use yarn or pnpm, adjust accordingly (e.g., copy yarn.lock or pnpm-lock.yaml and use yarn install or pnpm install)
 RUN npm install
 
 # Copy the rest of the frontend source code
@@ -16,48 +15,38 @@ COPY frontend/ ./
 # Build the frontend
 RUN npm run build
 
-# Stage 2: Python Backend
-FROM docker.io/langchain/langgraph-api:3.11
+# Stage 2: Python Backend for Cloud Run
+FROM python:3.11-slim
 
-# -- Install UV --
-# First install curl, then install UV using the standalone installer
-RUN apt-get update && apt-get install -y curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-ENV PATH="/root/.local/bin:$PATH"
-# -- End of UV installation --
+# Set working directory
+WORKDIR /app
 
-# -- Copy built frontend from builder stage --
-# The app.py expects the frontend build to be at ../frontend/dist relative to its own location.
-# If app.py is at /deps/backend/src/agent/app.py, then ../frontend/dist resolves to /deps/frontend/dist.
-COPY --from=frontend-builder /app/frontend/dist /deps/frontend/dist
-# -- End of copying built frontend --
+# Install dependencies
+RUN pip install --no-cache-dir \
+    "langgraph>=0.2.6" \
+    "langchain>=0.3.19" \
+    "langchain-google-genai" \
+    "langgraph-sdk>=0.1.57" \
+    "langgraph-cli" \
+    "langgraph-api" \
+    "fastapi" \
+    "google-genai"
 
-# -- Adding local package . --
-ADD backend/ /deps/backend
-# -- End of local package . --
+# Copy backend source code
+COPY backend/ /app/backend
 
-# -- Installing all local dependencies using UV --
-# First, we need to ensure pip is available for UV to use
-RUN uv pip install --system pip setuptools wheel
-# Install dependencies with UV, respecting constraints
-RUN cd /deps/backend && \
-    PYTHONDONTWRITEBYTECODE=1 UV_SYSTEM_PYTHON=1 uv pip install --system -c /api/constraints.txt -e .
-# -- End of local dependencies install --
-ENV LANGGRAPH_HTTP='{"app": "/deps/backend/src/agent/app.py:app"}'
-ENV LANGSERVE_GRAPHS='{"agent": "/deps/backend/src/agent/graph.py:graph"}'
+# Copy built frontend from builder stage
+COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
 
-# -- Ensure user deps didn't inadvertently overwrite langgraph-api
-# Create all required directories that the langgraph-api package expects
-RUN mkdir -p /api/langgraph_api /api/langgraph_runtime /api/langgraph_license /api/langgraph_storage && \
-    touch /api/langgraph_api/__init__.py /api/langgraph_runtime/__init__.py /api/langgraph_license/__init__.py /api/langgraph_storage/__init__.py
-# Use pip for this specific package as it has poetry-based build requirements
-RUN PYTHONDONTWRITEBYTECODE=1 pip install --no-cache-dir --no-deps -e /api
-# -- End of ensuring user deps didn't inadvertently overwrite langgraph-api --
-# -- Removing pip from the final image (but keeping UV) --
-RUN uv pip uninstall --system pip setuptools wheel && \
-    rm -rf /usr/local/lib/python*/site-packages/pip* /usr/local/lib/python*/site-packages/setuptools* /usr/local/lib/python*/site-packages/wheel* && \
-    find /usr/local/bin -name "pip*" -delete
-# -- End of pip removal --
+# Environment variables for LangGraph
+ENV LANGGRAPH_HTTP='{"app": "/app/backend/src/agent/app.py:app"}'
+ENV LANGSERVE_GRAPHS='{"agent": "/app/backend/src/agent/graph.py:graph"}'
+ENV LANGCHAIN_TRACING_V2="false"
 
-WORKDIR /deps/backend
+# Expose port 8080 for Cloud Run
+EXPOSE 8080
+
+# Start the application using langserve
+# The host and port will be managed by Cloud Run's environment variables.
+# langserve by default listens on port 8080, which is what Cloud Run expects.
+CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -1,7 +1,6 @@
 import os
 
 from agent.tools_and_schemas import SearchQueryList, Reflection
-from dotenv import load_dotenv
 from langchain_core.messages import AIMessage
 from langgraph.types import Send
 from langgraph.graph import StateGraph
@@ -32,7 +31,6 @@ from agent.utils import (
     resolve_urls,
 )
 
-load_dotenv()
 
 def print_current_credentials():
     """
@@ -47,11 +45,6 @@ def print_current_credentials():
     except google.auth.exceptions.DefaultCredentialsError:
         print("❌ Could not find default credentials. Please run 'gcloud auth application-default login'")
 
-#if os.getenv("GEMINI_API_KEY") is None:
-#    raise ValueError("GEMINI_API_KEY is not set")
-
-# Used for Google Search API
-#genai_client = Client(api_key=os.getenv("GEMINI_API_KEY"))
 print_current_credentials() # 現在の認証情報を表示
 genai_client = Client(vertexai=True, project="rd-simulation", location="us-east1")
 
@@ -81,7 +74,6 @@ def generate_query(state: OverallState, config: RunnableConfig) -> QueryGenerati
         model=configurable.query_generator_model,
         temperature=1.0,
         max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
     )
     structured_llm = llm.with_structured_output(SearchQueryList)
 
@@ -183,7 +175,6 @@ def reflection(state: OverallState, config: RunnableConfig) -> ReflectionState:
         model=reasoning_model,
         temperature=1.0,
         max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
     )
     result = llm.with_structured_output(Reflection).invoke(formatted_prompt)
 
@@ -262,7 +253,6 @@ def finalize_answer(state: OverallState, config: RunnableConfig):
         model=reasoning_model,
         temperature=0,
         max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
     )
     result = llm.invoke(formatted_prompt)
 


### PR DESCRIPTION
- Rewrites the Dockerfile to use a standard multi-stage build optimized for Cloud Run.
- Removes the dependency on LANGSMITH_API_KEY by setting LANGCHAIN_TRACING_V2 to 'false'.
- Modifies the backend to use GCP Application Default Credentials (ADC) for authentication with Google services, removing the need for a GEMINI_API_KEY.