### PR TITLE
fix: Use python -m to run langserve in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV LANGCHAIN_TRACING_V2="false"
 # Expose port 8080 for Cloud Run
 EXPOSE 8080
 
-# Start the application using langserve
+# Start the application using langserve as a python module
 # The host and port will be managed by Cloud Run's environment variables.
 # langserve by default listens on port 8080, which is what Cloud Run expects.
-CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["python", "-m", "langserve.cli", "up", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This changes the `CMD` instruction to run `langserve` as a Python module (`python -m langserve.cli`).

This is a more robust method that avoids issues with the system's `PATH` and ensures the executable can be found, which should resolve the persistent Cloud Run deployment error.