### PR TITLE
fix: Install langserve and set PYTHONPATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /app
 
 # Install dependencies
 RUN pip install --no-cache-dir \
+    "langserve" \
     "langgraph>=0.2.6" \
     "langchain>=0.3.19" \
     "langchain-google-genai" \
@@ -41,7 +42,8 @@ COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
 # Add pip's binary directory to PATH
 ENV PATH="/root/.local/bin:$PATH"
 
-# Environment variables for LangGraph
+# Add application source to PYTHONPATH and set up LangGraph variables
+ENV PYTHONPATH="/app/backend/src"
 ENV LANGGRAPH_HTTP='{"app": "/app/backend/src/agent/app.py:app"}'
 ENV LANGSERVE_GRAPHS='{"agent": "/app/backend/src/agent/graph.py:graph"}'
 ENV LANGCHAIN_TRACING_V2="false"


### PR DESCRIPTION
This commit addresses two issues that caused deployment failures:

1.  `ModuleNotFoundError: No module named 'langserve'`: The `langserve` package was missing from the `pip install` command. It is now explicitly added.
2.  Module resolution for the application: The application's own `agent` module could not be found by `langserve`. The `PYTHONPATH` is now set to include the application's source directory (`/app/backend/src`).

These changes should ensure the container builds correctly and the application starts successfully on Cloud Run.