### PR TITLE
fix: Use `python -m langserve` to run in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 8080
 # Start the application using langserve as a python module
 # The host and port will be managed by Cloud Run's environment variables.
 # langserve by default listens on port 8080, which is what Cloud Run expects.
-CMD ["python", "-m", "langserve.cli", "up", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["python", "-m", "langserve", "up", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This changes the `CMD` instruction to run `langserve` as a Python module using `python -m langserve`.

The previous attempt `python -m langserve.cli` failed with `No module named langserve.cli`. Running it as a top-level module `langserve` should work as it contains a `__main__.py` entrypoint.

This is the fourth attempt to fix the Cloud Run deployment. I am sincerely hoping this resolves the issue.