### PR TITLE
fix: Revert to original Dockerfile and adapt for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app/frontend
 # Copy frontend package files and install dependencies
 COPY frontend/package.json ./
 COPY frontend/package-lock.json ./
+# If you use yarn or pnpm, adjust accordingly (e.g., copy yarn.lock or pnpm-lock.yaml and use yarn install or pnpm install)
 RUN npm install
 
 # Copy the rest of the frontend source code
@@ -15,43 +16,55 @@ COPY frontend/ ./
 # Build the frontend
 RUN npm run build
 
-# Stage 2: Python Backend for Cloud Run
-FROM python:3.11-slim
+# Stage 2: Python Backend
+FROM docker.io/langchain/langgraph-api:3.11
 
-# Set working directory
-WORKDIR /app
-
-# Install dependencies
-RUN pip install --no-cache-dir \
-    "langserve" \
-    "langgraph>=0.2.6" \
-    "langchain>=0.3.19" \
-    "langchain-google-genai" \
-    "langgraph-sdk>=0.1.57" \
-    "langgraph-cli" \
-    "langgraph-api" \
-    "fastapi" \
-    "google-genai"
-
-# Copy backend source code
-COPY backend/ /app/backend
-
-# Copy built frontend from builder stage
-COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
-
-# Add pip's binary directory to PATH
+# -- Install UV --
+# First install curl, then install UV using the standalone installer
+RUN apt-get update && apt-get install -y curl && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.local/bin:$PATH"
+# -- End of UV installation --
 
-# Add application source to PYTHONPATH and set up LangGraph variables
-ENV PYTHONPATH="/app/backend/src"
-ENV LANGGRAPH_HTTP='{"app": "/app/backend/src/agent/app.py:app"}'
-ENV LANGSERVE_GRAPHS='{"agent": "/app/backend/src/agent/graph.py:graph"}'
+# -- Copy built frontend from builder stage --
+# The app.py expects the frontend build to be at ../frontend/dist relative to its own location.
+# If app.py is at /deps/backend/src/agent/app.py, then ../frontend/dist resolves to /deps/frontend/dist.
+COPY --from=frontend-builder /app/frontend/dist /deps/frontend/dist
+# -- End of copying built frontend --
+
+# -- Adding local package . --
+ADD backend/ /deps/backend
+# -- End of local package . --
+
+# -- Installing all local dependencies using UV --
+# First, we need to ensure pip is available for UV to use
+RUN uv pip install --system pip setuptools wheel
+# Install dependencies with UV, respecting constraints
+RUN cd /deps/backend && \
+    PYTHONDONTWRITEBYTECODE=1 UV_SYSTEM_PYTHON=1 uv pip install --system -c /api/constraints.txt -e .
+# -- End of local dependencies install --
+ENV LANGGRAPH_HTTP='{"app": "/deps/backend/src/agent/app.py:app"}'
+ENV LANGSERVE_GRAPHS='{"agent": "/deps/backend/src/agent/graph.py:graph"}'
+
+# -- Ensure user deps didn't inadvertently overwrite langgraph-api
+# Create all required directories that the langgraph-api package expects
+RUN mkdir -p /api/langgraph_api /api/langgraph_runtime /api/langgraph_license /api/langgraph_storage && \
+    touch /api/langgraph_api/__init__.py /api/langgraph_runtime/__init__.py /api/langgraph_license/__init__.py /api/langgraph_storage/__init__.py
+# Use pip for this specific package as it has poetry-based build requirements
+RUN PYTHONDONTWRITEBYTECODE=1 pip install --no-cache-dir --no-deps -e /api
+# -- End of ensuring user deps didn't inadvertently overwrite langgraph-api --
+# -- Removing pip from the final image (but keeping UV) --
+RUN uv pip uninstall --system pip setuptools wheel && \
+    rm -rf /usr/local/lib/python*/site-packages/pip* /usr/local/lib/python*/site-packages/setuptools* /usr/local/lib/python*/site-packages/wheel* && \
+    find /usr/local/bin -name "pip*" -delete
+# -- End of pip removal --
+
+WORKDIR /deps/backend
+
+# -- Cloud Run specific configuration --
+# Disable LangSmith tracing
 ENV LANGCHAIN_TRACING_V2="false"
-
-# Expose port 8080 for Cloud Run
+# Expose port and start the server
 EXPOSE 8080
-
-# Start the application using langserve as a python module
-# The host and port will be managed by Cloud Run's environment variables.
-# langserve by default listens on port 8080, which is what Cloud Run expects.
-CMD ["python", "-m", "langserve", "up", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
After multiple failed attempts to create a new Dockerfile from scratch, this commit reverts to the original, repository-provided Dockerfile.

The following minimal changes have been applied to this stable base:
1.  `ENV LANGCHAIN_TRACING_V2="false"` is added to disable the need for a LangSmith API key.
2.  `CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]` is added to provide an explicit start command for Cloud Run, ensuring the server listens on the correct port.

This approach leverages the tested and working configuration of the base image and should resolve the deployment issues.