### PR TITLE
fix: Provide default DATABASE_URI in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,9 @@ RUN uv pip uninstall --system pip setuptools wheel && \
 WORKDIR /deps/backend
 
 # -- Cloud Run specific configuration --
-# Disable LangSmith tracing
+# Disable LangSmith tracing and set a default database URI
 ENV LANGCHAIN_TRACING_V2="false"
+ENV DATABASE_URI="sqlite:////tmp/langgraph.db"
 # Expose port and start the server
 EXPOSE 8080
 CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This commit addresses the `KeyError: "Config 'DATABASE_URI' is missing"` error that occurred during application startup on Cloud Run.

The `langgraph-api` base image requires a database connection string to be configured. This change provides a default, ephemeral SQLite database URI (`sqlite:////tmp/langgraph.db`) by setting the `DATABASE_URI` environment variable in the `Dockerfile`.

This should satisfy the application's configuration requirements and allow it to start successfully.