### PR TITLE
fix: Set empty REDIS_URI in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ WORKDIR /deps/backend
 # Disable LangSmith tracing and set a default database URI
 ENV LANGCHAIN_TRACING_V2="false"
 ENV DATABASE_URI="sqlite:////tmp/langgraph.db"
+ENV REDIS_URI=""
 # Expose port and start the server
 EXPOSE 8080
 CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This commit addresses the `KeyError: "Config 'REDIS_URI' is missing"` error that occurred during application startup on Cloud Run.

Following the same pattern as the `DATABASE_URI` fix, this change provides an empty `REDIS_URI` environment variable. The hope is that this signals to the application that Redis is not configured, allowing it to fall back to an in-memory mode or disable features that require Redis.

This is a final attempt to resolve the chain of configuration errors required by the base image.