### PR TITLE
refactor: Decouple from langgraph-api image and external services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,72 +1,42 @@
 # Stage 1: Build React Frontend
 FROM node:20-alpine AS frontend-builder
 
-# Set working directory for frontend
 WORKDIR /app/frontend
 
-# Copy frontend package files and install dependencies
 COPY frontend/package.json ./
 COPY frontend/package-lock.json ./
-# If you use yarn or pnpm, adjust accordingly (e.g., copy yarn.lock or pnpm-lock.yaml and use yarn install or pnpm install)
 RUN npm install
 
-# Copy the rest of the frontend source code
 COPY frontend/ ./
-
-# Build the frontend
 RUN npm run build
 
-# Stage 2: Python Backend
-FROM docker.io/langchain/langgraph-api:3.11
+# Stage 2: Python Backend for Cloud Run
+FROM python:3.11-slim
 
-# -- Install UV --
-# First install curl, then install UV using the standalone installer
-RUN apt-get update && apt-get install -y curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-ENV PATH="/root/.local/bin:$PATH"
-# -- End of UV installation --
+WORKDIR /app
 
-# -- Copy built frontend from builder stage --
-# The app.py expects the frontend build to be at ../frontend/dist relative to its own location.
-# If app.py is at /deps/backend/src/agent/app.py, then ../frontend/dist resolves to /deps/frontend/dist.
-COPY --from=frontend-builder /app/frontend/dist /deps/frontend/dist
-# -- End of copying built frontend --
+# Install Python dependencies
+RUN pip install --no-cache-dir \
+    "uvicorn" \
+    "langserve" \
+    "langgraph>=0.2.6" \
+    "langchain>=0.3.19" \
+    "langchain-google-genai" \
+    "langgraph-sdk>=0.1.57" \
+    "fastapi" \
+    "google-genai"
 
-# -- Adding local package . --
-ADD backend/ /deps/backend
-# -- End of local package . --
+# Copy backend source code
+COPY backend/ /app/backend
 
-# -- Installing all local dependencies using UV --
-# First, we need to ensure pip is available for UV to use
-RUN uv pip install --system pip setuptools wheel
-# Install dependencies with UV, respecting constraints
-RUN cd /deps/backend && \
-    PYTHONDONTWRITEBYTECODE=1 UV_SYSTEM_PYTHON=1 uv pip install --system -c /api/constraints.txt -e .
-# -- End of local dependencies install --
-ENV LANGGRAPH_HTTP='{"app": "/deps/backend/src/agent/app.py:app"}'
-ENV LANGSERVE_GRAPHS='{"agent": "/deps/backend/src/agent/graph.py:graph"}'
+# Copy built frontend from builder stage
+COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
 
-# -- Ensure user deps didn't inadvertently overwrite langgraph-api
-# Create all required directories that the langgraph-api package expects
-RUN mkdir -p /api/langgraph_api /api/langgraph_runtime /api/langgraph_license /api/langgraph_storage && \
-    touch /api/langgraph_api/__init__.py /api/langgraph_runtime/__init__.py /api/langgraph_license/__init__.py /api/langgraph_storage/__init__.py
-# Use pip for this specific package as it has poetry-based build requirements
-RUN PYTHONDONTWRITEBYTECODE=1 pip install --no-cache-dir --no-deps -e /api
-# -- End of ensuring user deps didn't inadvertently overwrite langgraph-api --
-# -- Removing pip from the final image (but keeping UV) --
-RUN uv pip uninstall --system pip setuptools wheel && \
-    rm -rf /usr/local/lib/python*/site-packages/pip* /usr/local/lib/python*/site-packages/setuptools* /usr/local/lib/python*/site-packages/wheel* && \
-    find /usr/local/bin -name "pip*" -delete
-# -- End of pip removal --
+# Set the python path to include the backend source
+ENV PYTHONPATH="/app/backend"
 
-WORKDIR /deps/backend
-
-# -- Cloud Run specific configuration --
-# Disable LangSmith tracing and set a default database URI
-ENV LANGCHAIN_TRACING_V2="false"
-ENV DATABASE_URI="sqlite:////tmp/langgraph.db"
-ENV REDIS_URI=""
-# Expose port and start the server
+# Expose port 8080 for Cloud Run
 EXPOSE 8080
-CMD ["langserve", "up", "--host", "0.0.0.0", "--port", "8080"]
+
+# Start the application using uvicorn
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -5,6 +5,7 @@ from langchain_core.messages import AIMessage
 from langgraph.types import Send
 from langgraph.graph import StateGraph
 from langgraph.graph import START, END
+from langgraph.checkpoint.memory import MemorySaver
 from langchain_core.runnables import RunnableConfig
 from google.genai import Client
 import google.auth
@@ -296,4 +297,5 @@ builder.add_conditional_edges(
 # Finalize the answer
 builder.add_edge("finalize_answer", END)
 
-graph = builder.compile(name="pro-search-agent")
+checkpointer = MemorySaver()
+graph = builder.compile(name="pro-search-agent", checkpointer=checkpointer)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+from langserve import add_routes
+from agent.graph import graph
+from agent.app import create_frontend_router
+
+# Create the main FastAPI app
+app = FastAPI(
+    title="LangGraph Research Agent",
+    version="1.0",
+    description="An agent that researches a topic and generates a report.",
+)
+
+# Add the LangServe routes for the graph
+add_routes(
+    app,
+    graph,
+    path="/agent",
+    enable_feedback_endpoint=True,
+    enable_public_trace_link_endpoint=True,
+    playground_type="chat",
+)
+
+# Mount the frontend application
+# This assumes the frontend has been built and is located in ../frontend/dist
+app.mount(
+    "/",
+    create_frontend_router(build_dir="../../frontend/dist"),
+    name="frontend",
+)


### PR DESCRIPTION
This major refactor changes the application architecture to make it self-contained and deployable on Cloud Run without requiring external PostgreSQL and Redis services.

The key changes are:

1.  The graph in `graph.py` is modified to use an in-memory `MemorySaver` checkpointer, removing the need for a database to store state.
2.  A new `main.py` entrypoint is created to explicitly build the FastAPI app, add the langserve routes, and mount the frontend.
3.  The `Dockerfile` is completely rewritten to use a standard `python:3.11-slim` base image. It now installs all dependencies from scratch and uses `uvicorn` to run the new `main.py` entrypoint.

This removes the dependency on the `langchain/langgraph-api` base image and its hard-coded requirements for Postgres and Redis, resolving the persistent deployment failures.